### PR TITLE
Added npm scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ For any coders that want to help me:
 
 0. Install NodeJS if not done.
 1. Clone the repo.
-2. Install all dev dependencies with `npm i`. We recommend you to test your changes on a local server, using `http-server .`.
-3. Run `grunt` (concat, transpile es6 -> es5, uglify). Please, take your time to test the new changes you have done, otherwise I will NOT accept the pull request.
+2. Install all dev dependencies with `npm i`. We recommend you to test your changes on a local server, using `npm start`.
+3. Run `npm run build` (concat, transpile es6 -> es5, uglify). Please, take your time to test the new changes you have done, otherwise I will NOT accept the pull request.
 4. Create a new branch and make your changes on it, and do a pull request.
 
 ### "Mod" support:

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
     "type": "git",
     "url": "git+ssh://git@github.com/TotomInc/skid-inc.git"
   },
+  "scripts": {
+    "build": "grunt",
+    "start": "http-server ."
+  },
   "author": "Thomas Cazade (TotomInc)",
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
In the old version a contributor had to have `http-server` and `grunt` globally installed. I added scripts to the package.json in order to simplilfy contributing (from the package.json scope, you can reference packages even though they are not installed globally).

Added scripts:
- `npm start`: starts local webserver
- `npm build`: runs the default grunt task
